### PR TITLE
fix: persist tokens to xert-tokens.json instead of .env

### DIFF
--- a/scripts/setup-auth.ts
+++ b/scripts/setup-auth.ts
@@ -18,6 +18,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const projectRoot = path.resolve(__dirname, '..');
 const envPath = path.join(projectRoot, '.env');
+const tokenFilePath = path.join(projectRoot, 'xert-tokens.json');
 
 const XERT_TOKEN_URL = 'https://www.xertonline.com/oauth/token';
 const XERT_PUBLIC_CLIENT = { username: 'xert_public', password: 'xert_public' };
@@ -175,10 +176,19 @@ async function main(): Promise<void> {
     console.log(`   Scope: ${tokenResponse.scope}`);
     console.log('');
 
-    // Save tokens
+    // Save tokens to .env (for local development)
     updateEnvFile(tokenResponse.access_token, tokenResponse.refresh_token);
 
+    // Save tokens to xert-tokens.json (for container deployment)
+    const tokenData = {
+      accessToken: tokenResponse.access_token,
+      refreshToken: tokenResponse.refresh_token,
+      timestamp: new Date().toISOString(),
+    };
+    fs.writeFileSync(tokenFilePath, JSON.stringify(tokenData, null, 2) + '\n');
+
     console.log(`✅ Tokens saved to: ${envPath}`);
+    console.log(`✅ Token file saved to: ${tokenFilePath}`);
     console.log('');
     console.log('╔══════════════════════════════════════════════════════════════╗');
     console.log('║                    Setup Complete!                           ║');


### PR DESCRIPTION
## Summary
- Token refresh in the OpenClaw container was silently failing because `updateEnvFile()` wrote to `.env` in the read-only `vendor/` directory
- Tokens are now read from and written to `xert-tokens.json`, which has a writable bind-mount in the container (marakanda-infrastructure PR #97)
- On startup: env vars loaded first, then overridden by `xert-tokens.json` if present
- `setup-auth` now writes both `.env` (local dev) and `xert-tokens.json` (container deploy)

## Test plan
- [x] `npm run build` passes
- [ ] Deploy to Mac Mini, verify token refresh persists across container restarts
- [ ] Verify Sven (Fitness-Agent) can access XERT data